### PR TITLE
lib, query: remove manual implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,19 +88,10 @@ impl std::error::Error for ParseError {}
 ///
 /// - `query`: The SQL query string.
 /// - `tags`: A map of tag names to their corresponding values.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Query {
     pub query: String,
     pub tags: HashMap<String, String>,
-}
-
-impl Default for Query {
-    fn default() -> Self {
-        Query {
-            query: String::new(),
-            tags: HashMap::new(),
-        }
-    }
 }
 
 // Map of query names (--name from the file) to the Query.


### PR DESCRIPTION
Remove manual implementation of Default for Query. 
Fix is reported by `cargo clippy`.

Ref: https://rust-lang.github.io/rust-clippy/master/index.html#derivable_impls